### PR TITLE
Add version constraint for markupsafe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,27 +4,37 @@ on:
   push:
     tags:
       - 'cli-*.*.*'
+  workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: set env
       run: |
         echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-    - name: Build container
-      run: |
-        docker build -t pgadmin-schema-diff -f Dockerfile.cli .
+    - uses: docker/setup-qemu-action@v2
+        with:
+          platforms: amd64,arm64
+    - uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to ECR
+      uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Push to dockerhub
-      run: |
-        docker tag pgadmin-schema-diff supabase/pgadmin-schema-diff:latest
-        docker push supabase/pgadmin-schema-diff:latest
-
-        docker tag pgadmin-schema-diff supabase/pgadmin-schema-diff:$TAG
-        docker push supabase/pgadmin-schema-diff:$TAG
+        registry: public.ecr.aws
+        username: ${{ secrets.PROD_ACCESS_KEY_ID }}
+        password: ${{ secrets.PROD_SECRET_ACCESS_KEY }}
+    - uses: docker/build-push-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          supabase/pgadmin-schema-diff:latest
+          supabase/pgadmin-schema-diff:$TAG
+          public.ecr.aws/t3w2s2c9/pgadmin-schema-diff:latest
+          public.ecr.aws/t3w2s2c9/pgadmin-schema-diff:$TAG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         source venv/bin/activate
         python -m pip install -U pip setuptools wheel
         pip install pytest
-        pip install -r requirements.txt
+        pip install -r requirements.txt -c constraints.txt
 
     - name: run tests
       run: |

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -20,6 +20,7 @@ COPY web /pgadmin4/web
 
 # Install dependencies
 COPY requirements.txt /pgadmin4
+COPY constraints.txt /pgadmin4
 RUN rm -rf /pgadmin4/web/*.log \
            /pgadmin4/web/config_*.py \
            /pgadmin4/web/node_modules \
@@ -43,7 +44,7 @@ RUN apk add --no-cache \
         cargo \
         python3-dev && \
     python3 -m venv --system-site-packages --without-pip /venv && \
-    /venv/bin/python3 -m pip install --no-cache-dir -r requirements.txt && \
+    /venv/bin/python3 -m pip install --no-cache-dir -r requirements.txt -c constraints.txt && \
     apk del --no-cache build-deps
 
 #########################################################################

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,13 @@
+###############################################################################
+#
+# IMPORTANT:
+#
+# If runtime or build time dependencies are changed in this file, the committer
+# *must* ensure the DEB and RPM package maintainers are informed as soon as
+# possible.
+#
+###############################################################################
+
+# markupsafe removed soft_unicode in 2.1.0 which resulted in import error
+# https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0
+markupsafe==2.0.1


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

```bash
docker build -f Dockerfile.cli .
```

image built is not runnable due to broken dependency

## What is the new behavior?

Pin `markupsafe==2.0.1`

## Additional context

Add any other context or screenshots.
